### PR TITLE
Fix connection mapping removal logic

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServerEndpoint.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServerEndpoint.java
@@ -85,7 +85,7 @@ public class CacheServerEndpoint implements ServerSideConnectionAcceptor<CacheSe
         LOGGER.log(Level.SEVERE, "connectionClosed {0}", con);
         connections.remove(con.getConnectionId());
         if (con.getClientId() != null) {
-            clientConnections.remove(con.getClientId()); // to be remove only if the connection is the current connection
+            clientConnections.remove(con.getClientId(), con);// remove only if the closed connection is still mapped
         }
     }
 


### PR DESCRIPTION
## Summary
- avoid removing wrong client connection on close by using `ConcurrentHashMap.remove(key,value)`
- document conditional removal logic

## Testing
- `mvn -q -DskipTests install` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c25bcff0083209d596caa3b8a6781