### PR TITLE
Fix CacheClientBuilder javadoc

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/client/CacheClientBuilder.java
+++ b/blazingcache-core/src/main/java/blazingcache/client/CacheClientBuilder.java
@@ -218,8 +218,8 @@ public class CacheClientBuilder {
      * JMX flag to enable publishing of JMX status and statistics.
      *
      * @param jmx true in order to enable publication of status and statistics mbeans on JMX
-     * @return the instance of {
-     * @see CacheClientBuilder}
+     * @return the instance of CacheClientBuilder
+     * @see CacheClientBuilder
      */
     public CacheClientBuilder jmx(final boolean jmx) {
         this.jmx = jmx;
@@ -261,7 +261,7 @@ public class CacheClientBuilder {
     }
 
     /**
-     * Secret for autentication to the CacheServer.
+     * Secret for authentication to the CacheServer.
      *
      * @param clientSecret
      * @return


### PR DESCRIPTION
## Summary
- clean up Javadoc for `jmx` method
- fix typo in `clientSecret` Javadoc

## Testing
- `mvn -q -pl blazingcache-core -am -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c2a9e0d1083209f742ecde6f7e44e