### PR TITLE
Fix typo in test comments

### DIFF
--- a/blazingcache-core/src/test/java/blazingcache/client/ConcurrentFetchAndInvalidationTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ConcurrentFetchAndInvalidationTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/ErrorOnFetchTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ErrorOnFetchTest.java
@@ -36,7 +36,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/FetchPriorityTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/FetchPriorityTest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageAndSlowClientTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageAndSlowClientTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Test;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LockOnLostFetchMessageTest.java
@@ -35,7 +35,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageAutoCloseClientTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageAutoCloseClientTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */

--- a/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/LostFetchMessageTest.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test for slow cclients an fetches
+ * Test for slow clients and fetches
  *
  * @author enrico.olivelli
  */


### PR DESCRIPTION
## Summary
- correct the text 'slow cclients an fetches' to 'slow clients and fetches'

## Testing
- `grep -R "cclients an fetches" -n blazingcache-core/src/test/java/blazingcache/client`


------
https://chatgpt.com/codex/tasks/task_b_684c2a9cf1808320b0282febf73f1c3d