### PR TITLE
Add assertions for inserted key counts in status tests

### DIFF
--- a/blazingcache-core/src/test/java/blazingcache/client/ManagementStatusMXBeanTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ManagementStatusMXBeanTest.java
@@ -167,7 +167,6 @@ public final class ManagementStatusMXBeanTest {
                 //prepare for eviction
                 final Set<String> oneMoreKey = CacheClientTestUtils.fillCacheWithTestData(client, TEST_DATA, 1, 0);
                 assertEquals(1, oneMoreKey.size());
-                oneMoreKey.stream().findFirst().get();
 
                 usedMemory = (Long) JMXUtils.getMBeanServer().getAttribute(statusBeanName, "CacheUsedMemory");
                 assertEquals(TEST_DATA.length * MAX_NO_OF_ENTRIES_BEFORE_EVICTION + TEST_DATA.length, usedMemory);

--- a/blazingcache-core/src/test/java/blazingcache/client/ManagementStatusMXBeanTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/ManagementStatusMXBeanTest.java
@@ -146,6 +146,7 @@ public final class ManagementStatusMXBeanTest {
 
                 //fill cache with test values so as to check that memory usage goes up
                 final Set<String> insertedKeys = CacheClientTestUtils.fillCacheWithTestData(client, TEST_DATA, MAX_NO_OF_ENTRIES_BEFORE_EVICTION, 0);
+                assertEquals(MAX_NO_OF_ENTRIES_BEFORE_EVICTION, insertedKeys.size());
 
                 usedMemory = (Long) JMXUtils.getMBeanServer().getAttribute(statusBeanName, "CacheUsedMemory");
                 assertEquals(TEST_DATA.length * MAX_NO_OF_ENTRIES_BEFORE_EVICTION, usedMemory);
@@ -164,7 +165,9 @@ public final class ManagementStatusMXBeanTest {
                 }).collect(Collectors.toList());
 
                 //prepare for eviction
-                CacheClientTestUtils.fillCacheWithTestData(client, TEST_DATA, 1, 0).stream().findFirst().get();
+                final Set<String> oneMoreKey = CacheClientTestUtils.fillCacheWithTestData(client, TEST_DATA, 1, 0);
+                assertEquals(1, oneMoreKey.size());
+                oneMoreKey.stream().findFirst().get();
 
                 usedMemory = (Long) JMXUtils.getMBeanServer().getAttribute(statusBeanName, "CacheUsedMemory");
                 assertEquals(TEST_DATA.length * MAX_NO_OF_ENTRIES_BEFORE_EVICTION + TEST_DATA.length, usedMemory);

--- a/blazingcache-core/src/test/java/blazingcache/server/ManagementStatusMXBeanTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/server/ManagementStatusMXBeanTest.java
@@ -140,7 +140,9 @@ public final class ManagementStatusMXBeanTest {
 
             //put a few entries in client1 and client2 in order to assess the global cacheSize
             final Set<String> c1Keys = CacheClientTestUtils.fillCacheWithTestData(client1, TEST_DATA, 15, 0);
+            assertEquals(15, c1Keys.size());
             final Set<String> c2Keys = CacheClientTestUtils.fillCacheWithTestData(client2, TEST_DATA, 15, 0);
+            assertEquals(15, c2Keys.size());
             int globalCacheSize = (Integer) JMXUtils.getMBeanServer().getAttribute(statusS1BeanName, "GlobalCacheSize");
             assertEquals(30, globalCacheSize);
 
@@ -190,6 +192,7 @@ public final class ManagementStatusMXBeanTest {
             }
             assertTrue(client1.isConnected());
             Set<String> latestAddedKeys = CacheClientTestUtils.fillCacheWithTestData(client1, TEST_DATA, 12, 0);
+            assertEquals(12, latestAddedKeys.size());
             globalCacheSize = (Integer) JMXUtils.getMBeanServer().getAttribute(statusS2BeanName, "GlobalCacheSize");
             assertEquals(12, globalCacheSize);
 
@@ -215,6 +218,7 @@ public final class ManagementStatusMXBeanTest {
 
             //lock a few fresh entries
             latestAddedKeys = CacheClientTestUtils.fillCacheWithTestData(client1, TEST_DATA, 12, 0);
+            assertEquals(12, latestAddedKeys.size());
             final Set<KeyLock> acquiredLocks = new HashSet<>();
             latestAddedKeys.stream().forEach(key -> {
                 try {


### PR DESCRIPTION
## Summary
- add assertions verifying inserted key counts in `ManagementStatusMXBeanTest`

## Testing
- `mvn -q -pl blazingcache-core test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_b_684c2a9e6ec88320902e9d399f0ffd7e