### PR TITLE
Disconnect client after reply timeout

### DIFF
--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServer.java
@@ -75,6 +75,7 @@ public class CacheServer implements AutoCloseable {
     private long stateChangeTimestamp;
     private long slowClientTimeout = 120000;
     private long clientFetchTimeout = 2000;
+    private boolean disconnectClientsOnTimeout = true;
     private final long lastStartupTimestamp = System.currentTimeMillis();
     private boolean requireAuthentication = true;
 
@@ -596,6 +597,14 @@ public class CacheServer implements AutoCloseable {
 
     public void setClientFetchTimeout(long clientFetchTimeout) {
         this.clientFetchTimeout = clientFetchTimeout;
+    }
+
+    public boolean isDisconnectClientsOnTimeout() {
+        return disconnectClientsOnTimeout;
+    }
+
+    public void setDisconnectClientsOnTimeout(boolean disconnectClientsOnTimeout) {
+        this.disconnectClientsOnTimeout = disconnectClientsOnTimeout;
     }
 
     /**

--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServerEndpoint.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServerEndpoint.java
@@ -51,6 +51,7 @@ public class CacheServerEndpoint implements ServerSideConnectionAcceptor<CacheSe
         connection.setBroker(server);
         connection.setChannel(channel);
         connection.setRequireAuthentication(server.isRequireAuthentication());
+        connection.setDisconnectOnTimeout(server.isDisconnectClientsOnTimeout());
         channel.setMessagesReceiver(connection);
         connections.put(connection.getConnectionId(), connection);
         return connection;

--- a/blazingcache-core/src/main/java/blazingcache/server/CacheServerSideConnection.java
+++ b/blazingcache-core/src/main/java/blazingcache/server/CacheServerSideConnection.java
@@ -52,6 +52,7 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
     private volatile boolean authenticated;
     private volatile String username;
     private boolean requireAuthentication;
+    private boolean disconnectOnTimeout;
     private final long MAX_TS_DELTA = Long.getLong("blazingcache.server.maxclienttsdelta", 1000L * 60 * 60);
 
     private static final AtomicLong sessionId = new AtomicLong();
@@ -74,6 +75,14 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
 
     public void setRequireAuthentication(boolean requireAuthentication) {
         this.requireAuthentication = requireAuthentication;
+    }
+
+    public boolean isDisconnectOnTimeout() {
+        return disconnectOnTimeout;
+    }
+
+    public void setDisconnectOnTimeout(boolean disconnectOnTimeout) {
+        this.disconnectOnTimeout = disconnectOnTimeout;
     }
 
     public void setClientId(String clientId) {
@@ -517,6 +526,9 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
                     LOGGER.log(Level.SEVERE, "{0} not answered in time (elapsed {1} ms) to invalidation {2}: {3}, {4}",
                         new Object[]{clientId, _delta, key, message, error});
                     LOGGER.log(Level.SEVERE, "error for "+clientId, error);
+                    if (disconnectOnTimeout) {
+                        close();
+                    }
                 } else {
                     LOGGER.log(Level.FINEST, "{0} answered to invalidation {1}: {2}", new Object[]{clientId, key, message});
                 }
@@ -544,6 +556,9 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
                     LOGGER.log(Level.SEVERE, "{0} not answered in time (elapsed {1} ms) to put {2}: {3}, {4}",
                         new Object[]{clientId, _delta, key, message, error});
                     LOGGER.log(Level.SEVERE, "error for "+clientId, error);
+                    if (disconnectOnTimeout) {
+                        close();
+                    }
                 } else {
                     LOGGER.log(Level.FINEST, "{0} answered to put {1}: {2}", new Object[]{clientId, key, message});
                 }
@@ -568,6 +583,9 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
                 LOGGER.log(Level.FINEST, clientId + " answered to invalidateByPrefix " + prefix + ": " + message + ", " + error);
                 if (error != null) {
                     error.printStackTrace();
+                    if (disconnectOnTimeout) {
+                        close();
+                    }
                 }
                 // in ogni caso il client ha finito
                 invalidation.clientDone(clientId);
@@ -588,6 +606,9 @@ public class CacheServerSideConnection implements ChannelEventListener, ServerSi
                 LOGGER.log(Level.FINEST, remoteClientId + " answered to fetch key " + key + ": " + message + ", " + error);
                 if (error != null) {
                     error.printStackTrace();
+                    if (disconnectOnTimeout) {
+                        close();
+                    }
                 }
                 if (message != null) {
                     onFinish.onResult(message, null);

--- a/blazingcache-core/src/test/java/blazingcache/client/DisconnectOnTimeoutTest.java
+++ b/blazingcache-core/src/test/java/blazingcache/client/DisconnectOnTimeoutTest.java
@@ -1,0 +1,56 @@
+package blazingcache.client;
+
+import blazingcache.client.impl.InternalClientListener;
+import blazingcache.network.Channel;
+import blazingcache.network.Message;
+import blazingcache.network.ServerHostData;
+import blazingcache.network.netty.NettyCacheServerLocator;
+import blazingcache.server.CacheServer;
+import java.nio.charset.StandardCharsets;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+public class DisconnectOnTimeoutTest {
+
+    @Test
+    public void disconnectOnTimeout() throws Exception {
+        byte[] data = "testdata".getBytes(StandardCharsets.UTF_8);
+        ServerHostData serverHostData = new ServerHostData("localhost", 1234, "test", false, null);
+        try (CacheServer cacheServer = new CacheServer("ciao", serverHostData)) {
+            cacheServer.setSlowClientTimeout(1000);
+            cacheServer.setDisconnectClientsOnTimeout(true);
+            cacheServer.start();
+            try (CacheClient client1 = new CacheClient("theClient1", "ciao", new NettyCacheServerLocator(serverHostData));
+                 CacheClient client2 = new CacheClient("theClient2", "ciao", new NettyCacheServerLocator(serverHostData))) {
+                client1.start();
+                client2.start();
+                assertTrue(client1.waitForConnection(10000));
+                assertTrue(client2.waitForConnection(10000));
+
+                client1.setInternalClientListener(new InternalClientListener() {
+                    @Override
+                    public boolean messageReceived(Message message, Channel channel) {
+                        if (message.type == Message.TYPE_FETCH_ENTRY) {
+                            // ignore request to simulate timeout
+                            return false;
+                        }
+                        return true;
+                    }
+                });
+
+                client1.put("lost-fetch", data, 0);
+                assertNull(client2.fetch("lost-fetch"));
+
+                assertTrue(client1.waitForDisconnection(5000));
+
+                for (int i = 0; i < 50; i++) {
+                    if (cacheServer.getNumberOfConnectedClients() == 1) {
+                        break;
+                    }
+                    Thread.sleep(100);
+                }
+                assertEquals(1, cacheServer.getNumberOfConnectedClients());
+            }
+        }
+    }
+}

--- a/blazingcache-services/src/main/java/blazingcache/services/ServerMain.java
+++ b/blazingcache-services/src/main/java/blazingcache/services/ServerMain.java
@@ -155,6 +155,7 @@ public class ServerMain implements AutoCloseable {
         int channelHandlersThreads = Integer.parseInt(configuration.getProperty("channelhandlers.threads", "64"));
         int slowClientsTimeout = Integer.parseInt(configuration.getProperty("slow.clients.timeout", "120000"));
         int fetchClientsTimeout = Integer.parseInt(configuration.getProperty("fetch.clients.timeout", "2000"));
+        boolean disconnectClientsOnTimeout = Boolean.parseBoolean(configuration.getProperty("disconnect.clients.on.timeout", "true"));
 
         System.out.println("Starting BlazingCache Server");
 
@@ -163,6 +164,7 @@ public class ServerMain implements AutoCloseable {
         cacheServer = new CacheServer(sharedsecret, data);
         cacheServer.setSlowClientTimeout(slowClientsTimeout);
         cacheServer.setClientFetchTimeout(fetchClientsTimeout);
+        cacheServer.setDisconnectClientsOnTimeout(disconnectClientsOnTimeout);
         cacheServer.enableJmx(jmx);
 
         switch (clusteringmode) {

--- a/blazingcache-services/src/main/resources/conf/server.properties
+++ b/blazingcache-services/src/main/resources/conf/server.properties
@@ -47,3 +47,6 @@ slow.clients.timeout=120000
 
 # timeout for answers from clients for fetch
 fetch.clients.timeout=2000
+
+# disconnect unresponsive clients after reply timeout
+disconnect.clients.on.timeout=true


### PR DESCRIPTION
## Summary
- drop unresponsive clients once an invalidate/put/fetch request times out
- add new `disconnect.clients.on.timeout` configuration to toggle dropping behavior
- test disconnecting a client when the timeout triggers

## Testing
- `mvn -q -pl blazingcache-core -am test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_b_684c31e624cc8320b910a4cc8555d7ca